### PR TITLE
HDDS-13245. Reconciliation deleted block handling prototype

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerChecksumTreeManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerChecksumTreeManager.java
@@ -30,18 +30,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeMap;
-import java.util.TreeSet;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
@@ -81,78 +73,6 @@ public class ContainerChecksumTreeManager {
   }
 
   /**
-   * Writes the specified container merkle tree to the specified container's checksum file.
-   * The data merkle tree within the file is replaced with the {@code tree} parameter, but all other content of the
-   * file remains unchanged.
-   * Concurrent writes to the same file are coordinated internally.
-   */
-  public ContainerProtos.ContainerChecksumInfo writeContainerDataTree(ContainerData data,
-      ContainerMerkleTreeWriter tree) throws IOException {
-    long containerID = data.getContainerID();
-    ContainerProtos.ContainerChecksumInfo checksumInfo = null;
-    Lock writeLock = getLock(containerID);
-    writeLock.lock();
-    try {
-      ContainerProtos.ContainerChecksumInfo.Builder checksumInfoBuilder = readOrCreate(data).toBuilder();
-
-      ContainerProtos.ContainerMerkleTree treeProto = captureLatencyNs(metrics.getCreateMerkleTreeLatencyNS(),
-          tree::toProto);
-      checksumInfoBuilder
-          .setContainerID(containerID)
-          .setContainerMerkleTree(treeProto);
-      checksumInfo = checksumInfoBuilder.build();
-      write(data, checksumInfo);
-      LOG.debug("Data merkle tree for container {} updated with container checksum {}", containerID,
-          checksumToString(treeProto.getDataChecksum()));
-    } finally {
-      writeLock.unlock();
-    }
-    return checksumInfo;
-  }
-
-  /**
-   * Adds the specified blocks to the list of deleted blocks specified in the container's checksum file.
-   * All other content of the file remains unchanged.
-   * Concurrent writes to the same file are coordinated internally.
-   */
-  public void markBlocksAsDeleted(KeyValueContainerData data, Collection<Long> deletedBlockIDs) throws IOException {
-    long containerID = data.getContainerID();
-    Lock writeLock = getLock(containerID);
-    writeLock.lock();
-    try {
-      ContainerProtos.ContainerChecksumInfo.Builder checksumInfoBuilder = readOrCreate(data).toBuilder();
-
-      // Although the persisted block list should already be sorted, we will sort it here to make sure.
-      // This will automatically fix any bugs in the persisted order that may show up.
-      // TODO HDDS-13245 this conversion logic will be replaced and block checksums will be populated.
-      // Create BlockMerkleTree to wrap each input block ID.
-      List<ContainerProtos.BlockMerkleTree> deletedBlocks = deletedBlockIDs.stream()
-          .map(blockID ->
-              ContainerProtos.BlockMerkleTree.newBuilder().setBlockID(blockID).build())
-          .collect(Collectors.toList());
-      // Add the original blocks to the list.
-      deletedBlocks.addAll(checksumInfoBuilder.getDeletedBlocksList());
-      // Sort and deduplicate the list.
-      Map<Long, ContainerProtos.BlockMerkleTree> sortedDeletedBlocks = deletedBlocks.stream()
-          .collect(Collectors.toMap(ContainerProtos.BlockMerkleTree::getBlockID,
-              Function.identity(),
-              (a, b) -> a,
-              TreeMap::new));
-
-      checksumInfoBuilder
-          .setContainerID(containerID)
-          .clearDeletedBlocks()
-          .addAllDeletedBlocks(sortedDeletedBlocks.values());
-
-      write(data, checksumInfoBuilder.build());
-      LOG.debug("Deleted block list for container {} updated with {} new blocks", data.getContainerID(),
-          sortedDeletedBlocks.size());
-    } finally {
-      writeLock.unlock();
-    }
-  }
-
-  /**
    * Compares the checksum info of the container with the peer's checksum info and returns a report of the differences.
    * @param thisChecksumInfo The checksum info of the container on this datanode.
    * @param peerChecksumInfo The checksum info of the container on the peer datanode.
@@ -163,15 +83,14 @@ public class ContainerChecksumTreeManager {
 
     ContainerDiffReport report = new ContainerDiffReport(thisChecksumInfo.getContainerID());
     try {
+      Preconditions.assertNotNull(thisChecksumInfo, "Datanode's checksum info is null.");
+      Preconditions.assertNotNull(peerChecksumInfo, "Peer checksum info is null.");
+      if (thisChecksumInfo.getContainerID() != peerChecksumInfo.getContainerID()) {
+        throw new StorageContainerException("Container ID does not match. Local container ID "
+            + thisChecksumInfo.getContainerID() + " , Peer container ID " + peerChecksumInfo.getContainerID(),
+            ContainerProtos.Result.CONTAINER_ID_MISMATCH);
+      }
       captureLatencyNs(metrics.getMerkleTreeDiffLatencyNS(), () -> {
-        Preconditions.assertNotNull(thisChecksumInfo, "Datanode's checksum info is null.");
-        Preconditions.assertNotNull(peerChecksumInfo, "Peer checksum info is null.");
-        if (thisChecksumInfo.getContainerID() != peerChecksumInfo.getContainerID()) {
-          throw new StorageContainerException("Container ID does not match. Local container ID "
-              + thisChecksumInfo.getContainerID() + " , Peer container ID " + peerChecksumInfo.getContainerID(),
-              ContainerProtos.Result.CONTAINER_ID_MISMATCH);
-        }
-
         compareContainerMerkleTree(thisChecksumInfo, peerChecksumInfo, report);
       });
     } catch (IOException ex) {
@@ -186,6 +105,7 @@ public class ContainerChecksumTreeManager {
       metrics.incrementCorruptChunksIdentified(report.getNumCorruptChunks());
       metrics.incrementMissingBlocksIdentified(report.getNumMissingBlocks());
       metrics.incrementMissingChunksIdentified(report.getNumMissingChunks());
+      metrics.incrementDivergedDeletedBlocksIdentified(report.getNumDeletedBlocks());
     } else {
       metrics.incrementNoRepairContainerDiffs();
     }
@@ -197,8 +117,6 @@ public class ContainerChecksumTreeManager {
                                           ContainerDiffReport report) {
     ContainerProtos.ContainerMerkleTree thisMerkleTree = thisChecksumInfo.getContainerMerkleTree();
     ContainerProtos.ContainerMerkleTree peerMerkleTree = peerChecksumInfo.getContainerMerkleTree();
-    Set<Long> thisDeletedBlockSet = getDeletedBlockIDs(thisChecksumInfo);
-    Set<Long> peerDeletedBlockSet = getDeletedBlockIDs(peerChecksumInfo);
 
     if (thisMerkleTree.getDataChecksum() == peerMerkleTree.getDataChecksum()) {
       return;
@@ -214,16 +132,7 @@ public class ContainerChecksumTreeManager {
       ContainerProtos.BlockMerkleTree peerBlockMerkleTree = peerBlockMerkleTreeList.get(peerIdx);
 
       if (thisBlockMerkleTree.getBlockID() == peerBlockMerkleTree.getBlockID()) {
-        // Matching block ID; check if the block is deleted and handle the cases;
-        // 1) If the block is deleted in both the block merkle tree, We can ignore comparing them.
-        // 2) If the block is only deleted in our merkle tree, The BG service should have deleted our
-        //    block and the peer's BG service hasn't run yet. We can ignore comparing them.
-        // 3) If the block is only deleted in peer merkle tree, we can't reconcile for this block. It might be
-        //    deleted by peer's BG service. We can ignore comparing them.
-        // TODO: HDDS-11765 - Handle missed block deletions from the deleted block ids.
-        if (!thisDeletedBlockSet.contains(thisBlockMerkleTree.getBlockID()) &&
-            !peerDeletedBlockSet.contains(thisBlockMerkleTree.getBlockID()) &&
-            thisBlockMerkleTree.getDataChecksum() != peerBlockMerkleTree.getDataChecksum()) {
+        if (thisBlockMerkleTree.getDataChecksum() != peerBlockMerkleTree.getDataChecksum()) {
           compareBlockMerkleTree(thisBlockMerkleTree, peerBlockMerkleTree, report);
         }
         thisIdx++;
@@ -233,9 +142,11 @@ public class ContainerChecksumTreeManager {
         // doesn't have. We can skip these, the peer will pick up these block when it reconciles with our merkle tree.
         thisIdx++;
       } else {
-        // Peer block's ID is smaller; record missing block if peerDeletedBlockSet doesn't contain the blockId
+        // Peer block's ID is smaller, so we do not have this block. Add it to the corresponding list of missing blocks
         // and advance peerIdx
-        if (!peerDeletedBlockSet.contains(peerBlockMerkleTree.getBlockID())) {
+        if (peerBlockMerkleTree.getDeleted()) {
+          report.addDeletedBlock(peerBlockMerkleTree);
+        } else {
           report.addMissingBlock(peerBlockMerkleTree);
         }
         peerIdx++;
@@ -245,7 +156,9 @@ public class ContainerChecksumTreeManager {
     // Step 2: Process remaining blocks in the peer list
     while (peerIdx < peerBlockMerkleTreeList.size()) {
       ContainerProtos.BlockMerkleTree peerBlockMerkleTree = peerBlockMerkleTreeList.get(peerIdx);
-      if (!peerDeletedBlockSet.contains(peerBlockMerkleTree.getBlockID())) {
+      if (peerBlockMerkleTree.getDeleted()) {
+        report.addDeletedBlock(peerBlockMerkleTree);
+      } else {
         report.addMissingBlock(peerBlockMerkleTree);
       }
       peerIdx++;
@@ -256,6 +169,31 @@ public class ContainerChecksumTreeManager {
   }
 
   private void compareBlockMerkleTree(ContainerProtos.BlockMerkleTree thisBlockMerkleTree,
+      ContainerProtos.BlockMerkleTree peerBlockMerkleTree, ContainerDiffReport report) {
+
+    boolean thisBlockDeleted = thisBlockMerkleTree.getDeleted();
+    boolean peerBlockDeleted = peerBlockMerkleTree.getDeleted();
+
+    if (!thisBlockDeleted && !peerBlockDeleted) {
+      // Neither our nor peer's block is deleted. Walk the chunk list to find differences.
+      compareChunkMerkleTrees(thisBlockMerkleTree, peerBlockMerkleTree, report);
+    } else if (!thisBlockDeleted && peerBlockDeleted) {
+      // Our block has not yet been deleted, but peer's block has been.
+      // Mark our block as deleted to bring it in sync with the peer.
+      // Our block deleting service will eventually catch up.
+      // TODO HDDS-11765 Blocks deleted by a peer can also be deleted from our replica during reconciliation.
+      report.addDeletedBlock(peerBlockMerkleTree);
+    } else if (thisBlockDeleted && peerBlockDeleted) {
+      // Both us and peer's block is deleted. Since there is no data corresponding
+      // TODO lexigraphical max
+      if (thisBlockMerkleTree.getDataChecksum() < peerBlockMerkleTree.getDataChecksum()) {
+        report.addDeletedBlock(peerBlockMerkleTree);
+      }
+    }
+    // Else, our block is deleted but the peer's is not. Peer needs to update their block.
+  }
+
+  private void compareChunkMerkleTrees(ContainerProtos.BlockMerkleTree thisBlockMerkleTree,
                                       ContainerProtos.BlockMerkleTree peerBlockMerkleTree,
                                       ContainerDiffReport report) {
 
@@ -348,6 +286,14 @@ public class ContainerChecksumTreeManager {
     }
   }
 
+  public void mergeAllBlocksAndWrite(ContainerData data, ContainerMerkleTreeWriter newTree) throws IOException {
+    write(data, newTree, false);
+  }
+
+  public void setDataBlocksAndWrite(ContainerData data, ContainerMerkleTreeWriter newTree) throws IOException {
+    write(data, newTree, true);
+  }
+
   /**
    * Reads the checksum info of the specified container. If the tree file with the information does not exist, or there
    * is an exception trying to read the file, an empty instance is returned.
@@ -364,35 +310,57 @@ public class ContainerChecksumTreeManager {
   }
 
   /**
-   * Callers should have acquired the write lock before calling this method.
+   * Writes the specified container merkle tree to the specified container's checksum file.
+   * Concurrent writes to the same file are coordinated internally.
+   *
+   * @param data The container to update the tree for.
+   * @param treeWriter The merkle tree with updated for this container.
+   * @param replaceData Specified how the provided treeWriter will be merged with the merkle tree already on disk.
+   *      if true: Data blocks which are not marked as deleted will be cleared from the previous tree and those in the incoming tree will be used.
+   *      if false: Data blocks which are not marked as deleted will be merged with the set of data blocks from the disk. Those
+   *                    TODO
+   *
    */
-  private void write(ContainerData data, ContainerProtos.ContainerChecksumInfo checksumInfo) throws IOException {
-    // Make sure callers filled in required fields before writing.
-    Preconditions.assertTrue(checksumInfo.hasContainerID());
+  private void write(ContainerData data, ContainerMerkleTreeWriter treeWriter, boolean replaceData) throws IOException {
+    long containerID = data.getContainerID();
+    Lock fileLock = getLock(containerID);
+    fileLock.lock();
+    try {
+      // Merge the incoming merkle tree with the content already on the disk.
+      ContainerProtos.ContainerChecksumInfo currentChecksumInfo = readOrCreate(data);
+      if (replaceData) {
+        treeWriter.clearData();
+      }
+      treeWriter.merge(currentChecksumInfo.getContainerMerkleTree());
 
-    File checksumFile = getContainerChecksumFile(data);
-    File tmpChecksumFile = getTmpContainerChecksumFile(data);
+      // Write the updated merkle tree to the file.
+      ContainerProtos.ContainerChecksumInfo.Builder newChecksumInfoBuilder = currentChecksumInfo.toBuilder();
+      newChecksumInfoBuilder.setContainerID(containerID);
+      ContainerProtos.ContainerMerkleTree treeProto = captureLatencyNs(metrics.getCreateMerkleTreeLatencyNS(),
+          treeWriter::toProto);
+      newChecksumInfoBuilder.setContainerMerkleTree(treeProto);
 
-    try (OutputStream tmpOutputStream = Files.newOutputStream(tmpChecksumFile.toPath())) {
-      // Write to a tmp file and rename it into place.
-      captureLatencyNs(metrics.getWriteContainerMerkleTreeLatencyNS(), () -> {
-        checksumInfo.writeTo(tmpOutputStream);
-        Files.move(tmpChecksumFile.toPath(), checksumFile.toPath(), ATOMIC_MOVE);
-      });
-    } catch (IOException ex) {
-      // If the move failed and left behind the tmp file, the tmp file will be overwritten on the next successful write.
-      // Nothing reads directly from the tmp file.
-      metrics.incrementMerkleTreeWriteFailures();
-      throw new IOException("Error occurred when writing container merkle tree for containerID "
-          + data.getContainerID(), ex);
+      File checksumFile = getContainerChecksumFile(data);
+      File tmpChecksumFile = getTmpContainerChecksumFile(data);
+
+      try (OutputStream tmpOutputStream = Files.newOutputStream(tmpChecksumFile.toPath())) {
+        // Write to a tmp file and rename it into place.
+        captureLatencyNs(metrics.getWriteContainerMerkleTreeLatencyNS(), () -> {
+          newChecksumInfoBuilder.build().writeTo(tmpOutputStream);
+          Files.move(tmpChecksumFile.toPath(), checksumFile.toPath(), ATOMIC_MOVE);
+        });
+        LOG.debug("Merkle tree for container {} updated with container data checksum {}", containerID,
+            checksumToString(treeProto.getDataChecksum()));
+      } catch (IOException ex) {
+        // If the move failed and left behind the tmp file, the tmp file will be overwritten on the next successful
+        // write. Nothing reads directly from the tmp file.
+        metrics.incrementMerkleTreeWriteFailures();
+        throw new IOException("Error occurred when writing container merkle tree for containerID "
+            + data.getContainerID(), ex);
+      }
+    } finally {
+      fileLock.unlock();
     }
-  }
-
-  // TODO HDDS-13245 This method will no longer be required.
-  private SortedSet<Long> getDeletedBlockIDs(ContainerProtos.ContainerChecksumInfoOrBuilder checksumInfo) {
-    return checksumInfo.getDeletedBlocksList().stream()
-        .map(ContainerProtos.BlockMerkleTree::getBlockID)
-        .collect(Collectors.toCollection(TreeSet::new));
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerDiffReport.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerDiffReport.java
@@ -132,6 +132,10 @@ public class ContainerDiffReport {
         " Diverged Deleted Blocks: " + getNumDeletedBlocks();
   }
 
+  /**
+   * Represents a block that has been deleted in a peer whose metadata we need to add to our container replica's
+   * merkle tree.
+   */
   public static class DeletedBlock {
     private final long blockID;
     private final long dataChecksum;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerDiffReport.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerDiffReport.java
@@ -31,12 +31,14 @@ public class ContainerDiffReport {
   private final List<ContainerProtos.BlockMerkleTree> missingBlocks;
   private final Map<Long, List<ContainerProtos.ChunkMerkleTree>> missingChunks;
   private final Map<Long, List<ContainerProtos.ChunkMerkleTree>> corruptChunks;
+  private final List<DeletedBlock> deletedBlocks;
   private final long containerID;
 
   public ContainerDiffReport(long containerID) {
     this.missingBlocks = new ArrayList<>();
     this.missingChunks = new HashMap<>();
     this.corruptChunks = new HashMap<>();
+    this.deletedBlocks = new ArrayList<>();
     this.containerID = containerID;
   }
 
@@ -67,6 +69,10 @@ public class ContainerDiffReport {
     this.corruptChunks.computeIfAbsent(blockId, any -> new ArrayList<>()).add(corruptChunk);
   }
 
+  public void addDeletedBlock(ContainerProtos.BlockMerkleTree blockMerkleTree) {
+    this.deletedBlocks.add(new DeletedBlock(blockMerkleTree.getBlockID(), blockMerkleTree.getDataChecksum()));
+  }
+
   /**
    * @return A list of BlockMerkleTree objects that were reported as missing.
    */
@@ -88,13 +94,17 @@ public class ContainerDiffReport {
     return corruptChunks;
   }
 
+  public List<DeletedBlock> getDeletedBlocks() {
+    return deletedBlocks;
+  }
+
   /**
    * If needRepair is true, It means current replica needs blocks/chunks from the peer to repair
    * its container replica. The peer replica still may have corruption, which it will fix when
    * it reconciles with other peers.
    */
   public boolean needsRepair() {
-    return !missingBlocks.isEmpty() || !missingChunks.isEmpty() || !corruptChunks.isEmpty();
+    return !missingBlocks.isEmpty() || !missingChunks.isEmpty() || !corruptChunks.isEmpty() || !deletedBlocks.isEmpty();
   }
 
   public long getNumCorruptChunks() {
@@ -109,11 +119,34 @@ public class ContainerDiffReport {
     return missingBlocks.size();
   }
 
+  public long getNumDeletedBlocks() {
+    return deletedBlocks.size();
+  }
+
   @Override
   public String toString() {
     return "Diff report for container " + containerID + ":" +
         " Missing Blocks: " + getNumMissingBlocks() +
         " Missing Chunks: " + getNumMissingChunks() + " chunks from " + missingChunks.size() + " blocks" +
-        " Corrupt Chunks: " + getNumCorruptChunks() + " chunks from " + corruptChunks.size() + " blocks";
+        " Corrupt Chunks: " + getNumCorruptChunks() + " chunks from " + corruptChunks.size() + " blocks" +
+        " Diverged Deleted Blocks: " + getNumDeletedBlocks();
+  }
+
+  public static class DeletedBlock {
+    private final long blockID;
+    private final long dataChecksum;
+
+    public DeletedBlock(long blockID, long dataChecksum) {
+      this.blockID = blockID;
+      this.dataChecksum = dataChecksum;
+    }
+
+    public long getBlockID() {
+      return blockID;
+    }
+
+    public long getDataChecksum() {
+      return dataChecksum;
+    }
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerMerkleTreeMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerMerkleTreeMetrics.java
@@ -54,6 +54,9 @@ public class ContainerMerkleTreeMetrics {
   @Metric(about = "Number of corrupt chunks identified during container reconciliation")
   private MutableCounterLong numCorruptChunksIdentified;
 
+  @Metric(about = "Number of diverged block deletes identified during container reconciliation")
+  private MutableCounterLong numDivergedDeletedBlocksIdentified;
+
   @Metric(about = "Merkle tree write latency")
   private MutableRate merkleTreeWriteLatencyNS;
 
@@ -110,6 +113,10 @@ public class ContainerMerkleTreeMetrics {
   }
 
   public void incrementCorruptChunksIdentified(long value) {
+    this.numCorruptChunksIdentified.incr(value);
+  }
+
+  public void incrementDivergedDeletedBlocksIdentified(long value) {
     this.numCorruptChunksIdentified.incr(value);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerMerkleTreeMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerMerkleTreeMetrics.java
@@ -117,8 +117,9 @@ public class ContainerMerkleTreeMetrics {
   }
 
   public void incrementDivergedDeletedBlocksIdentified(long value) {
-    this.numCorruptChunksIdentified.incr(value);
+    this.numDivergedDeletedBlocksIdentified.incr(value);
   }
+
 
   public MutableRate getWriteContainerMerkleTreeLatencyNS() {
     return this.merkleTreeWriteLatencyNS;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerMerkleTreeWriter.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerMerkleTreeWriter.java
@@ -211,16 +211,16 @@ public class ContainerMerkleTreeWriter {
     private boolean deleted;
     private long dataChecksum;
 
-    public BlockMerkleTreeWriter(long blockID) {
+    BlockMerkleTreeWriter(long blockID) {
       this.blockID = blockID;
       this.offset2Chunk = new TreeMap<>();
       this.deleted = false;
       this.dataChecksum = 0;
     }
 
-    public void markDeleted(long dataChecksum) {
+    public void markDeleted(long deletedDataChecksum) {
       this.deleted = true;
-      this.dataChecksum = dataChecksum;
+      this.dataChecksum = deletedDataChecksum;
     }
 
     public void markDeleted() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerMerkleTreeWriter.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerMerkleTreeWriter.java
@@ -108,7 +108,8 @@ public class ContainerMerkleTreeWriter {
     id2Block.put(blockID, blockWriter);
   }
 
-  public ContainerProtos.ContainerMerkleTree mergeDeletedBlocks(ContainerProtos.ContainerMerkleTree existingTree) {
+  public ContainerProtos.ContainerMerkleTree update(
+      ContainerProtos.ContainerMerkleTree existingTree) {
     return merge(existingTree, false);
   }
 
@@ -133,7 +134,8 @@ public class ContainerMerkleTreeWriter {
    * scanner's value because it would again diverge from the peer due to data that is expected to be deleted.
    * This would cause the checksum to oscillate back and forth until the block is deleted, instead of converging.
    */
-  private ContainerProtos.ContainerMerkleTree merge(ContainerProtos.ContainerMerkleTree existingTree, boolean mergeLiveBlocks) {
+  private ContainerProtos.ContainerMerkleTree merge(ContainerProtos.ContainerMerkleTree existingTree,
+      boolean mergeLiveBlocks) {
     for (ContainerProtos.BlockMerkleTree existingBlockTree: existingTree.getBlockMerkleTreeList()) {
       long blockID = existingBlockTree.getBlockID();
       BlockMerkleTreeWriter ourBlockTree = id2Block.get(blockID);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerMerkleTreeWriter.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerMerkleTreeWriter.java
@@ -91,14 +91,26 @@ public class ContainerMerkleTreeWriter {
     id2Block.computeIfAbsent(blockID, BlockMerkleTreeWriter::new);
   }
 
-  // Used when reconciling deleted blocks
+  /**
+   * Creates a deleted block entry in the merkle tree and assigns the block this fixed checksum.
+   * If the block already exists with child data it is overwritten.
+   *
+   * This method is used on the reconciliation path to update the data checksum used for a deleted block based on a
+   * peer's value.
+   */
   public void setDeletedBlock(long blockID, long dataChecksum) {
     BlockMerkleTreeWriter blockWriter = new BlockMerkleTreeWriter(blockID);
     blockWriter.markDeleted(dataChecksum);
     id2Block.put(blockID, blockWriter);
   }
 
-  // Used by block deleting service
+  /**
+   * Creates a deleted block entry in the merkle tree and assigns the block a checksum computed from the chunk metadata
+   * in the provided BlockData object.
+   *
+   * This method is used by the block deleting service to add a marker to the tree for a block that has been deleted so
+   * that the deletion does not alter the data checksum.
+   */
   public void setDeletedBlock(long blockID, BlockData blockData) {
     BlockMerkleTreeWriter blockWriter = new BlockMerkleTreeWriter(blockID);
     for (ContainerProtos.ChunkInfo chunkInfo: blockData.getChunks()) {
@@ -196,7 +208,7 @@ public class ContainerMerkleTreeWriter {
         .setDataChecksum(checksumImpl.getValue());
   }
 
-  private ContainerProtos.ContainerMerkleTree toProto() {
+  public ContainerProtos.ContainerMerkleTree toProto() {
     return toProtoBuilder().build();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1654,7 +1654,7 @@ public class KeyValueHandler extends Handler {
         // This will be updated as we do repairs with this peer, then used to write the updated tree for the diff with
         // the next peer.
         ContainerMerkleTreeWriter updatedTreeWriter = new ContainerMerkleTreeWriter();
-        updatedTreeWriter.merge(latestChecksumInfo.getContainerMerkleTree());
+        updatedTreeWriter.update(latestChecksumInfo.getContainerMerkleTree());
         ContainerDiffReport diffReport = checksumManager.diff(latestChecksumInfo, peerChecksumInfo);
         Pipeline pipeline = createSingleNodePipeline(peer);
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
@@ -301,8 +301,7 @@ public final class KeyValueContainerUtil {
       }
 
       ContainerChecksumInfo containerChecksumInfo = ContainerChecksumTreeManager.readChecksumInfo(kvContainerData);
-      if (containerChecksumInfo != null && containerChecksumInfo.hasContainerMerkleTree()
-          && kvContainerData.needsDataChecksum()) {
+      if (ContainerChecksumTreeManager.hasDataChecksum(containerChecksumInfo) && kvContainerData.needsDataChecksum()) {
         containerDataChecksum = containerChecksumInfo.getContainerMerkleTree().getDataChecksum();
         kvContainerData.setDataChecksum(containerDataChecksum);
         metadataTable.put(kvContainerData.getContainerDataChecksumKey(), containerDataChecksum);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingTask.java
@@ -231,7 +231,7 @@ public class BlockDeletingTask implements BackgroundTask {
       // Mark blocks as deleted in the container checksum tree.
       // Data for these blocks does not need to be copied during container reconciliation if container replicas diverge.
       // Do this before the delete transactions are removed from the database.
-      checksumTreeManager.merge(containerData, treeWriter);
+      checksumTreeManager.mergeTree(containerData, treeWriter);
 
       // Once chunks in the blocks are deleted... remove the blockID from
       // blockDataTable.
@@ -370,7 +370,7 @@ public class BlockDeletingTask implements BackgroundTask {
       // Data for these blocks does not need to be copied if container replicas diverge during container reconciliation.
       // Do this before the delete transactions are removed from the database.
       // TODO need to get block data
-      checksumTreeManager.markBlocksAsDeleted(containerData, crr.getDeletedBlocks());
+//      checksumTreeManager.merge(containerData, crr.getDeletedBlocks());
 
       // Once blocks are deleted... remove the blockID from blockDataTable
       // and also remove the transactions from txnTable.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingTask.java
@@ -26,11 +26,14 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.utils.BackgroundTask;
@@ -193,8 +196,8 @@ public class BlockDeletingTask implements BackgroundTask {
         return crr;
       }
 
-      List<Long> succeedBlockIDs = new LinkedList<>();
-      List<String> succeedBlockDBKeys = new LinkedList<>();
+      // Maps the key in the DB to the block metadata for blocks that were successfully deleted.
+      Map<String, BlockData> succeedDeletedBlocks = new HashMap<>();
       LOG.debug("{}, toDeleteBlocks: {}", containerData, toDeleteBlocks.size());
 
       Handler handler = Objects.requireNonNull(ozoneContainer.getDispatcher()
@@ -215,12 +218,7 @@ public class BlockDeletingTask implements BackgroundTask {
         try {
           handler.deleteBlock(container, blockData);
           releasedBytes += KeyValueContainerUtil.getBlockLength(blockData);
-          long blockID = blockData.getLocalID();
-          succeedBlockIDs.add(blockID);
-          succeedBlockDBKeys.add(blockName);
-
-          treeWriter.setDeletedBlock(blockID, blockData);
-          treeWriter.addChunks(blockID, true, blockData.getChunks());
+          succeedDeletedBlocks.put(blockName, blockData);
         } catch (InvalidProtocolBufferException e) {
           LOG.error("Failed to parse block info for block {}", blockName, e);
         } catch (IOException e) {
@@ -231,13 +229,13 @@ public class BlockDeletingTask implements BackgroundTask {
       // Mark blocks as deleted in the container checksum tree.
       // Data for these blocks does not need to be copied during container reconciliation if container replicas diverge.
       // Do this before the delete transactions are removed from the database.
-      checksumTreeManager.mergeTree(containerData, treeWriter);
+      checksumTreeManager.addDeletedBlocks(containerData, succeedDeletedBlocks.values());
 
       // Once chunks in the blocks are deleted... remove the blockID from
       // blockDataTable.
       try (BatchOperation batch = meta.getStore().getBatchHandler()
           .initBatchOperation()) {
-        for (String key: succeedBlockDBKeys) {
+        for (String key: succeedDeletedBlocks.keySet()) {
           blockDataTable.deleteWithBatch(batch, key);
         }
 
@@ -246,7 +244,7 @@ public class BlockDeletingTask implements BackgroundTask {
         // updated with decremented used bytes during deleteChunk. This is
         // done here so that all the DB update for block delete can be
         // batched together while committing to DB.
-        int deletedBlocksCount = succeedBlockDBKeys.size();
+        int deletedBlocksCount = succeedDeletedBlocks.size();
         containerData.updateAndCommitDBCounters(meta, batch,
             deletedBlocksCount, releasedBytes);
         // Once DB update is persisted, check if there are any blocks
@@ -264,13 +262,15 @@ public class BlockDeletingTask implements BackgroundTask {
         metrics.incrSuccessBytes(releasedBytes);
       }
 
-      if (!succeedBlockDBKeys.isEmpty()) {
+      if (!succeedDeletedBlocks.isEmpty()) {
         LOG.debug("Container: {}, deleted blocks: {}, space reclaimed: {}, " +
                 "task elapsed time: {}ms", containerData.getContainerID(),
-            succeedBlockDBKeys.size(), releasedBytes,
+            succeedDeletedBlocks.size(), releasedBytes,
             Time.monotonicNow() - startTime);
       }
-      crr.addAll(succeedBlockIDs);
+      crr.addAll(succeedDeletedBlocks.values().stream()
+          .map(BlockData::getLocalID)
+          .collect(Collectors.toList()));
       return crr;
     } catch (IOException exception) {
       LOG.warn("Deletion operation was not successful for container: " +
@@ -366,12 +366,6 @@ public class BlockDeletingTask implements BackgroundTask {
       deleteBlocksResult.deletedBlocksTxs().forEach(
           tx -> crr.addAll(tx.getLocalIDList()));
 
-      // Mark blocks as deleted in the container checksum tree.
-      // Data for these blocks does not need to be copied if container replicas diverge during container reconciliation.
-      // Do this before the delete transactions are removed from the database.
-      // TODO need to get block data
-//      checksumTreeManager.merge(containerData, crr.getDeletedBlocks());
-
       // Once blocks are deleted... remove the blockID from blockDataTable
       // and also remove the transactions from txnTable.
       try (BatchOperation batch = meta.getStore().getBatchHandler()
@@ -438,7 +432,7 @@ public class BlockDeletingTask implements BackgroundTask {
     Instant startTime = Instant.now();
 
     // Track deleted blocks to avoid duplicate deletion
-    Set<Long> deletedBlockSet = new HashSet<>();
+    Map<Long, BlockData> deletedBlocks = new HashMap<>();
 
     for (DeletedBlocksTransaction entry : delBlocks) {
       for (Long blkLong : entry.getLocalIDList()) {
@@ -446,7 +440,7 @@ public class BlockDeletingTask implements BackgroundTask {
         blocksProcessed++;
 
         // Check if the block has already been deleted
-        if (deletedBlockSet.contains(blkLong)) {
+        if (deletedBlocks.containsKey(blkLong)) {
           LOG.debug("Skipping duplicate deletion for block {}", blkLong);
           continue;
         }
@@ -471,7 +465,7 @@ public class BlockDeletingTask implements BackgroundTask {
           blocksDeleted++;
           deleted = true;
           // Track this block as deleted
-          deletedBlockSet.add(blkLong);
+          deletedBlocks.put(blkLong, blkInfo);
         } catch (IOException e) {
           // TODO: if deletion of certain block retries exceed the certain
           //  number of times, service should skip deleting it,
@@ -499,6 +493,7 @@ public class BlockDeletingTask implements BackgroundTask {
         break;
       }
     }
+    checksumTreeManager.addDeletedBlocks(containerData, deletedBlocks.values());
     return new DeleteTransactionStats(blocksProcessed,
         blocksDeleted, bytesReleased, deletedBlocksTxs);
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/checksum/ContainerMerkleTreeTestUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/checksum/ContainerMerkleTreeTestUtils.java
@@ -75,6 +75,7 @@ public final class ContainerMerkleTreeTestUtils {
 
       assertEquals(expectedBlockTree.getBlockID(), actualBlockTree.getBlockID());
       assertEquals(expectedBlockTree.getDataChecksum(), actualBlockTree.getDataChecksum());
+      assertEquals(expectedBlockTree.getDeleted(), actualBlockTree.getDeleted());
 
       long prevChunkOffset = -1;
       for (int chunkIndex = 0; chunkIndex < expectedBlockTree.getChunkMerkleTreeCount(); chunkIndex++) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/checksum/ContainerMerkleTreeTestUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/checksum/ContainerMerkleTreeTestUtils.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
@@ -43,6 +44,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ozone.HddsDatanodeService;
+import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.DBHandle;
@@ -385,5 +387,14 @@ public final class ContainerMerkleTreeTestUtils {
           "the one in the checksum file.");
       assertEquals(dbDataChecksum, dataChecksum);
     }
+  }
+
+  public static BlockData buildBlockData(ConfigurationSource config, long containerID, long blockID) {
+    BlockData blockData = new BlockData(new BlockID(containerID, blockID));
+    byte byteValue = 0;
+    blockData.addChunk(buildChunk(config, 0, ByteBuffer.wrap(new byte[]{byteValue++, byteValue++, byteValue++})));
+    blockData.addChunk(buildChunk(config, 1, ByteBuffer.wrap(new byte[]{byteValue++, byteValue++, byteValue++})));
+    blockData.addChunk(buildChunk(config, 2, ByteBuffer.wrap(new byte[]{byteValue++, byteValue++, byteValue++})));
+    return blockData;
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/checksum/TestContainerMerkleTreeWriter.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/checksum/TestContainerMerkleTreeWriter.java
@@ -69,9 +69,8 @@ class TestContainerMerkleTreeWriter {
 
     // Build the expected tree proto using the test code.
     ContainerProtos.ChunkMerkleTree chunkTree = buildExpectedChunkTree(chunk);
-    ContainerProtos.BlockMerkleTree blockTree = buildExpectedBlockTree(blockID,
-        Collections.singletonList(chunkTree));
-    ContainerProtos.ContainerMerkleTree expectedTree = buildExpectedContainerTree(Collections.singletonList(blockTree));
+    ContainerProtos.BlockMerkleTree blockTree = buildExpectedBlockTree(blockID, chunkTree);
+    ContainerProtos.ContainerMerkleTree expectedTree = buildExpectedContainerTree(blockTree);
 
     // Use the ContainerMerkleTreeWriter to build the same tree.
     ContainerMerkleTreeWriter actualTree = new ContainerMerkleTreeWriter();
@@ -106,8 +105,8 @@ class TestContainerMerkleTreeWriter {
 
     // Build the expected tree proto using the test code.
     ContainerProtos.BlockMerkleTree blockTree = buildExpectedBlockTree(blockID,
-        Arrays.asList(buildExpectedChunkTree(chunk1), buildExpectedChunkTree(chunk3)));
-    ContainerProtos.ContainerMerkleTree expectedTree = buildExpectedContainerTree(Collections.singletonList(blockTree));
+        buildExpectedChunkTree(chunk1), buildExpectedChunkTree(chunk3));
+    ContainerProtos.ContainerMerkleTree expectedTree = buildExpectedContainerTree(blockTree);
 
     // Use the ContainerMerkleTree to build the same tree.
     ContainerMerkleTreeWriter actualTree = new ContainerMerkleTreeWriter();
@@ -218,8 +217,8 @@ class TestContainerMerkleTreeWriter {
   @Test
   public void testBuildTreeWithEmptyBlock() {
     final long blockID = 1;
-    ContainerProtos.BlockMerkleTree blockTree = buildExpectedBlockTree(blockID, Collections.emptyList());
-    ContainerProtos.ContainerMerkleTree expectedTree = buildExpectedContainerTree(Collections.singletonList(blockTree));
+    ContainerProtos.BlockMerkleTree blockTree = buildExpectedBlockTree(blockID);
+    ContainerProtos.ContainerMerkleTree expectedTree = buildExpectedContainerTree(blockTree);
 
     // Use the ContainerMerkleTree to build the same tree.
     ContainerMerkleTreeWriter actualTree = new ContainerMerkleTreeWriter();
@@ -236,8 +235,8 @@ class TestContainerMerkleTreeWriter {
     // Build the expected proto.
     ContainerProtos.ChunkInfo chunk1 = buildChunk(config, 0, ByteBuffer.wrap(new byte[]{1, 2, 3}));
     ContainerProtos.BlockMerkleTree blockTree = buildExpectedBlockTree(blockID,
-        Collections.singletonList(buildExpectedChunkTree(chunk1)));
-    ContainerProtos.ContainerMerkleTree expectedTree = buildExpectedContainerTree(Collections.singletonList(blockTree));
+        buildExpectedChunkTree(chunk1));
+    ContainerProtos.ContainerMerkleTree expectedTree = buildExpectedContainerTree(blockTree);
 
     // Use the ContainerMerkleTree to build the same tree, calling addBlock in between adding chunks.
     ContainerMerkleTreeWriter actualTree = new ContainerMerkleTreeWriter();
@@ -266,11 +265,10 @@ class TestContainerMerkleTreeWriter {
 
     // Build the expected tree proto using the test code.
     ContainerProtos.BlockMerkleTree blockTree1 = buildExpectedBlockTree(blockID1,
-        Arrays.asList(buildExpectedChunkTree(b1c1), buildExpectedChunkTree(b1c2)));
+        buildExpectedChunkTree(b1c1), buildExpectedChunkTree(b1c2));
     ContainerProtos.BlockMerkleTree blockTree3 = buildExpectedBlockTree(blockID3,
-        Arrays.asList(buildExpectedChunkTree(b3c1), buildExpectedChunkTree(b3c2)));
-    ContainerProtos.ContainerMerkleTree expectedTree = buildExpectedContainerTree(
-        Arrays.asList(blockTree1, blockTree3));
+        buildExpectedChunkTree(b3c1), buildExpectedChunkTree(b3c2));
+    ContainerProtos.ContainerMerkleTree expectedTree = buildExpectedContainerTree(blockTree1, blockTree3);
 
     // Use the ContainerMerkleTree to build the same tree.
     // Add blocks and chunks out of order to test sorting.
@@ -299,13 +297,12 @@ class TestContainerMerkleTreeWriter {
 
     // Build the expected tree proto using the test code.
     ContainerProtos.BlockMerkleTree blockTree1 = buildExpectedBlockTree(blockID1,
-        Arrays.asList(buildExpectedChunkTree(b1c1), buildExpectedChunkTree(b1c2), buildExpectedChunkTree(b1c3)));
+        buildExpectedChunkTree(b1c1), buildExpectedChunkTree(b1c2), buildExpectedChunkTree(b1c3));
     ContainerProtos.BlockMerkleTree blockTree2 = buildExpectedBlockTree(blockID2,
-        Arrays.asList(buildExpectedChunkTree(b2c1), buildExpectedChunkTree(b2c2)));
+        buildExpectedChunkTree(b2c1), buildExpectedChunkTree(b2c2));
     ContainerProtos.BlockMerkleTree blockTree3 = buildExpectedBlockTree(blockID3,
-        Arrays.asList(buildExpectedChunkTree(b3c1), buildExpectedChunkTree(b3c2)));
-    ContainerProtos.ContainerMerkleTree expectedTree = buildExpectedContainerTree(
-        Arrays.asList(blockTree1, blockTree2, blockTree3));
+        buildExpectedChunkTree(b3c1), buildExpectedChunkTree(b3c2));
+    ContainerProtos.ContainerMerkleTree expectedTree = buildExpectedContainerTree(blockTree1, blockTree2, blockTree3);
 
     // Use the ContainerMerkleTree to build the same tree.
     // Test building by adding chunks to the blocks individually and out of order.
@@ -420,15 +417,14 @@ class TestContainerMerkleTreeWriter {
     ContainerProtos.ChunkInfo b2c1 = buildChunk(config, 0, ByteBuffer.wrap(new byte[]{1, 2, 3}));
     ContainerProtos.ChunkInfo b2c2 = buildChunk(config, 1, ByteBuffer.wrap(new byte[]{1, 2, 3}));
     ContainerProtos.BlockMerkleTree blockTree1 = buildExpectedBlockTree(blockID1,
-        Arrays.asList(buildExpectedChunkTree(b1c1), buildExpectedChunkTree(b1c2), buildExpectedChunkTree(b1c3)));
+        buildExpectedChunkTree(b1c1), buildExpectedChunkTree(b1c2), buildExpectedChunkTree(b1c3));
     ContainerProtos.BlockMerkleTree blockTree2 = buildExpectedBlockTree(blockID2,
-        Arrays.asList(buildExpectedChunkTree(b2c1), buildExpectedChunkTree(b2c2)));
+        buildExpectedChunkTree(b2c1), buildExpectedChunkTree(b2c2));
     // Test that an empty block is preserved during tree conversion.
-    ContainerProtos.BlockMerkleTree blockTree3 = buildExpectedBlockTree(blockID3, Collections.emptyList());
+    ContainerProtos.BlockMerkleTree blockTree3 = buildExpectedBlockTree(blockID3);
     // Test that a deleted block is preserved during tree conversion.
     ContainerProtos.BlockMerkleTree blockTree4 = buildExpectedDeletedBlockTree(blockID4, deletedBlockChecksum);
-    ContainerProtos.ContainerMerkleTree expectedTree = buildExpectedContainerTree(
-        Arrays.asList(blockTree1, blockTree2, blockTree3, blockTree4));
+    ContainerProtos.ContainerMerkleTree expectedTree = buildExpectedContainerTree(blockTree1, blockTree2, blockTree3, blockTree4);
 
     ContainerMerkleTreeWriter treeWriter = new ContainerMerkleTreeWriter(expectedTree);
     ContainerProtos.ContainerMerkleTree actualTree = treeWriter.toProto();
@@ -439,10 +435,9 @@ class TestContainerMerkleTreeWriter {
     treeWriter.addChunks(blockID3, false, b3c1);
     treeWriter.addBlock(blockID5);
 
-    blockTree3 = buildExpectedBlockTree(blockID3, Collections.singletonList(buildExpectedChunkTree(b3c1, false)));
-    ContainerProtos.BlockMerkleTree blockTree5 = buildExpectedBlockTree(blockID5, Collections.emptyList());
-    ContainerProtos.ContainerMerkleTree expectedUpdatedTree = buildExpectedContainerTree(
-        Arrays.asList(blockTree1, blockTree2, blockTree3, blockTree4, blockTree5));
+    blockTree3 = buildExpectedBlockTree(blockID3, buildExpectedChunkTree(b3c1, false));
+    ContainerProtos.BlockMerkleTree blockTree5 = buildExpectedBlockTree(blockID5);
+    ContainerProtos.ContainerMerkleTree expectedUpdatedTree = buildExpectedContainerTree(blockTree1, blockTree2, blockTree3, blockTree4, blockTree5);
 
     assertTreesSortedAndMatch(expectedUpdatedTree, treeWriter.toProto());
   }
@@ -595,26 +590,178 @@ class TestContainerMerkleTreeWriter {
     assertNotEquals(liveBlockChecksum, finalBlock.getDataChecksum());
   }
 
+  /**
+   * If both trees contain a block and ours is live while existing is deleted,
+   * the deleted one supersedes and its checksum should be used.
+   */
+  @Test
+  public void testUpdateConflictExistingDeleted() {
+    final long blockID = 1L;
 
-  private ContainerProtos.ContainerMerkleTree buildExpectedContainerTree(List<ContainerProtos.BlockMerkleTree> blocks) {
+    // Our writer has a live block
+    ContainerMerkleTreeWriter writer = new ContainerMerkleTreeWriter();
+    ContainerProtos.ChunkInfo chunk = buildChunk(config, 0, ByteBuffer.wrap(new byte[]{1, 2, 3}));
+    writer.addChunks(blockID, true, chunk);
+
+    // Existing tree marks the same block as deleted with a specific checksum
+    final long deletedChecksum = 987654321L;
+    ContainerProtos.BlockMerkleTree existingDeleted = buildExpectedDeletedBlockTree(blockID, deletedChecksum);
+    ContainerProtos.ContainerMerkleTree existingTree = ContainerProtos.ContainerMerkleTree.newBuilder()
+        .addBlockMerkleTree(existingDeleted)
+        .build();
+
+    ContainerProtos.ContainerMerkleTree result = writer.update(existingTree);
+
+    // Expect the deleted state from existing to override the live state in writer
+    ContainerProtos.ContainerMerkleTree expected = buildExpectedContainerTree(
+        buildExpectedDeletedBlockTree(blockID, deletedChecksum));
+    assertTreesSortedAndMatch(expected, result);
+  }
+
+  /**
+   * If both trees contain the same live block, our writer's value wins.
+   */
+  @Test
+  public void testUpdateConflictBothLive() {
+    final long blockID = 1L;
+
+    // Our writer live block with one set of chunks
+    ContainerMerkleTreeWriter writer = new ContainerMerkleTreeWriter();
+    ContainerProtos.ChunkInfo ourChunk = buildChunk(config, 0, ByteBuffer.wrap(new byte[]{10, 20, 30}));
+    writer.addChunks(blockID, true, ourChunk);
+
+    // Existing tree has same blockID but different content
+    ContainerProtos.ChunkInfo existingChunk = buildChunk(config, 0, ByteBuffer.wrap(new byte[]{7, 8, 9}));
+    ContainerProtos.BlockMerkleTree existingLive = buildExpectedBlockTree(blockID,
+        buildExpectedChunkTree(existingChunk));
+    ContainerProtos.ContainerMerkleTree existingTree = ContainerProtos.ContainerMerkleTree.newBuilder()
+        .addBlockMerkleTree(existingLive)
+        .build();
+
+    ContainerProtos.ContainerMerkleTree result = writer.update(existingTree);
+
+    // Expect our writer's live block to be preserved
+    ContainerProtos.ContainerMerkleTree expected = buildExpectedContainerTree(
+        buildExpectedBlockTree(blockID, buildExpectedChunkTree(ourChunk)));
+    assertTreesSortedAndMatch(expected, result);
+  }
+
+  /**
+   * If our writer has a deleted block and the existing tree has it as live,
+   * our deleted value wins since we have the latest information.
+   */
+  @Test
+  public void testUpdateConflictExistingLive() {
+    final long blockID = 3L;
+
+    // Our writer marks the block as deleted
+    final long ourDeletedChecksum = 12345L;
+    ContainerMerkleTreeWriter writer = new ContainerMerkleTreeWriter();
+    writer.setDeletedBlock(blockID, ourDeletedChecksum);
+
+    // Existing tree has a live version of the block
+    ContainerProtos.ChunkInfo existingChunk = buildChunk(config, 0, ByteBuffer.wrap(new byte[]{4, 5, 6}));
+    ContainerProtos.BlockMerkleTree existingLive = buildExpectedBlockTree(blockID,
+        buildExpectedChunkTree(existingChunk));
+    ContainerProtos.ContainerMerkleTree existingTree = ContainerProtos.ContainerMerkleTree.newBuilder()
+        .addBlockMerkleTree(existingLive)
+        .build();
+
+    ContainerProtos.ContainerMerkleTree result = writer.update(existingTree);
+
+    // Expect our deleted entry to be preserved
+    ContainerProtos.ContainerMerkleTree expected = buildExpectedContainerTree(
+        buildExpectedDeletedBlockTree(blockID, ourDeletedChecksum));
+    assertTreesSortedAndMatch(expected, result);
+  }
+
+  /**
+   * If both the writer's tree and existing tree have deleted versions of a block, our writer's checksum wins.
+   */
+  @Test
+  public void testUpdateConflictBothDeleted() {
+    final long blockID = 4L;
+    final long ourDeletedChecksum = 111L;
+    final long existingDeletedChecksum = 222L;
+
+    ContainerMerkleTreeWriter writer = new ContainerMerkleTreeWriter();
+    writer.setDeletedBlock(blockID, ourDeletedChecksum);
+
+    ContainerProtos.BlockMerkleTree existingDeleted = buildExpectedDeletedBlockTree(blockID, existingDeletedChecksum);
+    ContainerProtos.ContainerMerkleTree existingTree = ContainerProtos.ContainerMerkleTree.newBuilder()
+        .addBlockMerkleTree(existingDeleted)
+        .build();
+
+    ContainerProtos.ContainerMerkleTree result = writer.update(existingTree);
+
+    ContainerProtos.ContainerMerkleTree expected = buildExpectedContainerTree(
+        buildExpectedDeletedBlockTree(blockID, ourDeletedChecksum));
+    assertTreesSortedAndMatch(expected, result);
+  }
+
+  /**
+   * Merge the existing tree with the tree writer by:
+   * - including deleted blocks from the existing tree into our tree writer.
+   * - ignoring live blocks from the existing tree and overwriting them with our tree writer.
+   */
+  @Test
+  public void testUpdateMergesTrees() {
+    final long existingLiveBlockID = 6L;
+    final long existingDeletedBlockID = 5L;
+    final long existingDeletedChecksum = 555L;
+    final long ourLiveBlockID = 7L;
+    final long ourDeletedBlockID = 8L;
+    final long ourDeletedChecksum = 444L;
+
+    // Our writer contains a live block not present in the existing tree
+    ContainerMerkleTreeWriter writer = new ContainerMerkleTreeWriter();
+    ContainerProtos.ChunkInfo ourLiveChunk = buildChunk(config, 0, ByteBuffer.wrap(new byte[]{9, 9, 9}));
+    writer.addChunks(ourLiveBlockID, true, ourLiveChunk);
+    // Our writer also includes a deleted block not present in the existing tree
+    writer.setDeletedBlock(ourDeletedBlockID, ourDeletedChecksum);
+
+    // Existing tree contains a deleted block (should be included) and a live block (should be ignored)
+    ContainerProtos.BlockMerkleTree existingDeleted = buildExpectedDeletedBlockTree(existingDeletedBlockID, existingDeletedChecksum);
+    ContainerProtos.ChunkInfo existingLiveChunk = buildChunk(config, 0, ByteBuffer.wrap(new byte[]{7, 7, 7}));
+    ContainerProtos.BlockMerkleTree existingLiveBlock = buildExpectedBlockTree(existingLiveBlockID,
+        buildExpectedChunkTree(existingLiveChunk));
+    ContainerProtos.ContainerMerkleTree existingTree = ContainerProtos.ContainerMerkleTree.newBuilder()
+        .addBlockMerkleTree(existingDeleted)
+        .addBlockMerkleTree(existingLiveBlock)
+        .build();
+
+    ContainerProtos.ContainerMerkleTree result = writer.update(existingTree);
+
+    // Expect union: our live block + existing deleted block, but not the existing live block
+    ContainerProtos.ContainerMerkleTree expected = buildExpectedContainerTree(
+        buildExpectedBlockTree(ourLiveBlockID, buildExpectedChunkTree(ourLiveChunk)),
+        buildExpectedDeletedBlockTree(existingDeletedBlockID, existingDeletedChecksum),
+        buildExpectedDeletedBlockTree(ourDeletedBlockID, ourDeletedChecksum));
+    assertTreesSortedAndMatch(expected, result);
+  }
+
+  private ContainerProtos.ContainerMerkleTree buildExpectedContainerTree(
+      ContainerProtos.BlockMerkleTree... blocks) {
+    List<ContainerProtos.BlockMerkleTree> blockList = Arrays.asList(blocks);
     return ContainerProtos.ContainerMerkleTree.newBuilder()
-        .addAllBlockMerkleTree(blocks)
+        .addAllBlockMerkleTree(blockList)
         .setDataChecksum(computeExpectedChecksum(
-            blocks.stream()
+            blockList.stream()
                 .map(ContainerProtos.BlockMerkleTree::getDataChecksum)
                 .collect(Collectors.toList())))
         .build();
   }
 
   private ContainerProtos.BlockMerkleTree buildExpectedBlockTree(long blockID,
-      List<ContainerProtos.ChunkMerkleTree> chunks) {
-    List<Long> itemsToChecksum = chunks.stream().map(ContainerProtos.ChunkMerkleTree::getDataChecksum)
+      ContainerProtos.ChunkMerkleTree... chunks) {
+    List<ContainerProtos.ChunkMerkleTree> chunkList = Arrays.asList(chunks);
+    List<Long> itemsToChecksum = chunkList.stream().map(ContainerProtos.ChunkMerkleTree::getDataChecksum)
         .collect(Collectors.toList());
     itemsToChecksum.add(0, blockID);
     return ContainerProtos.BlockMerkleTree.newBuilder()
         .setBlockID(blockID)
         .setDataChecksum(computeExpectedChecksum(itemsToChecksum))
-        .addAllChunkMerkleTree(chunks)
+        .addAllChunkMerkleTree(chunkList)
         .setDeleted(false)
         .build();
   }

--- a/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
@@ -566,6 +566,7 @@ message BlockMerkleTree {
   optional int64 blockID = 1;
   optional int64 dataChecksum = 2;
   repeated ChunkMerkleTree chunkMerkleTree = 3;
+  optional bool deleted = 4;
 }
 
 message ContainerMerkleTree {
@@ -576,7 +577,6 @@ message ContainerMerkleTree {
 message ContainerChecksumInfo {
   optional int64 containerID = 1;
   optional ContainerMerkleTree containerMerkleTree = 2;
-  repeated BlockMerkleTree deletedBlocks = 3;
 }
 
 service XceiverClientProtocolService {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Prototype for deleted block handling:
- Pushes as much logic as possible down into the `ContainerMerkleTreeWriter` and `ContainerChecksumTreeManager` to avoid complicating scanner, block delete, and reconciliation.
- Stores deleted blocks in the merkle tree instead of a separate list.
  - This aims to unify handling during the diff computation
- Resolves conflicts between peer checksums for deleted blocks using a simple max of the checksums
  - Once data is deleted, we just need checksums to converge to a value. It does not have to be the correct one, and without data present it may be impossible to determine which was the correct one that actually matched the data.
- Since the block deleting service can add deleted nodes to the tree before the container scanner gets to it, the data checksum is not updated in this case.
  - Existing code has been modified to check data checksum existence using the `dataChecksum` field in the tree, instead of assuming tree existence implies there will be a data checksum. 

## What is the link to the Apache JIRA

HDDS-13245

## How was this patch tested?

Pending
